### PR TITLE
fixed order of crossposts

### DIFF
--- a/lib/octopress-multilingual.rb
+++ b/lib/octopress-multilingual.rb
@@ -27,7 +27,7 @@ module Octopress
         ## Add posts that crosspost to all languages
         .each do |lang, posts|
           if lang != main_language
-            posts.concat(crossposts).sort_by(&:date).reverse
+            posts.concat(crossposts).sort_by!(&:date).reverse!
           end
         end
 


### PR DESCRIPTION
if a language had crossposts, they were simply appended to the end of the list without reordering them by date
