### PR TITLE
Use Jekyll Hooks (when Jekyll 3.0 ships)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 mkmf.log
 _site
 .sass-cache
+.jekyll-metadata

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 rvm:
   - 2.0.0
-  - 1.9.3
 script: bundle exec clash test

--- a/lib/octopress-multilingual.rb
+++ b/lib/octopress-multilingual.rb
@@ -1,4 +1,3 @@
-require 'octopress-hooks'
 require 'liquid'
 
 require "octopress-multilingual/version"
@@ -8,6 +7,7 @@ require "octopress-multilingual/filters"
 require "octopress-multilingual/hooks"
 require "octopress-multilingual/jekyll"
 require "octopress-multilingual/command"
+require "octopress-debugger"
 
 module Octopress
   module Multilingual
@@ -170,40 +170,41 @@ module Octopress
       @tags[lang] || {}
     end
 
-    def page_payload(lang)
-      payload = {
-        'site' => { 
+    def page_payload(lang, payload={})
+      if lang
+        payload['site'] ||= {}
+
+        {
           'posts'      => posts_by_language(lang),
           'linkposts'  => linkposts_by_language(lang),
           'articles'   => articles_by_language(lang),
           'categories' => categories_by_language(lang),
           'tags'       => tags_by_language(lang)
-        },
-        'lang' => lang_dict[lang]
-      }
+        }.each do |key, value|
+          payload['site'][key] = value
+        end
 
-      if defined?(Octopress::Ink) && site.config['lang']
-        payload.merge!(Octopress::Ink.payload(lang))
+        payload['lang'] = lang_dict[lang]
+
+        if defined?(Octopress::Ink) && site.config['lang']
+          payload.merge!(Octopress::Ink.payload(lang))
+        end
       end
 
       payload
     end
 
-    def site_payload
+    def site_payload(payload)
       if main_language
-        @payload ||= {
-          'site' => {
-            'posts_by_language'      => posts_by_language,
-            'linkposts_by_language'  => linkposts_by_language,
-            'articles_by_language'   => articles_by_language,
-            'categories_by_language' => categories_by_language,
-            'tags_by_language'       => tags_by_language,
-            'languages'              => languages
-          },
-          'lang' => lang_dict[main_language]
-        }
-      else
-        {}
+        payload['site'].merge!({
+          'posts_by_language'      => posts_by_language,
+          'linkposts_by_language'  => linkposts_by_language,
+          'articles_by_language'   => articles_by_language,
+          'categories_by_language' => categories_by_language,
+          'tags_by_language'       => tags_by_language,
+          'languages'              => languages
+        })
+        payload['lang'] = lang_dict[main_language]
       end
     end
   end

--- a/lib/octopress-multilingual/hooks.rb
+++ b/lib/octopress-multilingual/hooks.rb
@@ -1,56 +1,36 @@
 module Octopress
   module Multilingual
-    class SiteHook < Hooks::Site
-      priority :high
-      # Generate site_payload so other plugins can access
-      def post_read(site)
-        Octopress::Multilingual.site = site
-        site.config['languages'] = Octopress::Multilingual.languages
+    Jekyll::Hooks.register :site, :post_read, priority: :high do |site|
+      Octopress::Multilingual.site = site
+      site.config['languages'] = Octopress::Multilingual.languages
+    end
+
+    Jekyll::Hooks.register :site, :pre_render, priority: :high do |site, payload|
+      [site.pages, site.posts].flatten.select(&:translated).each do |item|
+        # Access array of translated items via (post/page).translations
+        item.data.merge!({
+          'translations' => item.translations,
+          'translated' => item.translated
+        })
       end
 
-      def pre_render(site)
+      Octopress::Multilingual.site_payload payload
+    end
 
-        # Add translation page data to each page or post.
-        #
-        [site.pages, site.posts].flatten.select(&:translated).each do |item|
-          # Access array of translated items via (post/page).translations
-          item.data.merge!({
-            'translations' => item.translations,
-            'translated' => item.translated
-          })
-        end
-      end
-
-      def merge_payload(payload, site)
-        Octopress::Multilingual.site_payload
+    Jekyll::Hooks.register [:page, :post], :post_init, priority: :high do |item|
+      if item.lang == 'default'
+        item.data['lang'] = item.site.config['lang']
       end
     end
 
-    class PagePayloadHook < Hooks::All
-      priority :high
-
-      def post_init(item)
-        if item.lang == 'default'
-          item.data['lang'] = item.site.config['lang']
-        end
+    Jekyll::Hooks.register :document, :pre_render, priority: :high do |item|
+      if item.lang == 'default'
+        item.data['lang'] = item.site.config['lang']
       end
+    end
 
-      # Swap out post arrays with posts of the approrpiate language
-      #
-      def merge_payload(payload, item)
-        if item.lang
-          Octopress::Multilingual.page_payload(item.lang)
-        end
-      end
-
-      # Override deep_merge to prevent categories and tags from being combined when they shouldn't
-      #
-      def deep_merge_payload(page_payload, hook_payload)
-        %w{site page}.each do |key|
-          hook_payload[key] = page_payload[key].merge(hook_payload[key] || {})
-        end
-        hook_payload
-      end
+    Jekyll::Hooks.register [:page, :post, :document], :pre_render, priority: :high do |item, payload|
+      Octopress::Multilingual.page_payload(item.lang, payload)
     end
   end
 end

--- a/octopress-multilingual.gemspec
+++ b/octopress-multilingual.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "octopress-hooks"
+  spec.add_runtime_dependency "jekyll", "~> 3.0"
 
   spec.add_development_dependency "octopress"
   spec.add_development_dependency "octopress-linkblog"

--- a/octopress-multilingual.gemspec
+++ b/octopress-multilingual.gemspec
@@ -25,7 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  if RUBY_VERSION >= "2"
-    spec.add_development_dependency "octopress-debugger"
-  end
+  spec.add_development_dependency "octopress-debugger"
 end

--- a/octopress-multilingual.gemspec
+++ b/octopress-multilingual.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", "~> 3.0"
+  spec.add_runtime_dependency "jekyll", ">= 3.0.0.a", "< 4"
 
   spec.add_development_dependency "octopress"
   spec.add_development_dependency "octopress-linkblog"


### PR DESCRIPTION
This will switch to using Jekyll hooks instead of Octopress hooks. Hurray!
